### PR TITLE
Fix curly braces in get_project_env() to fix #3

### DIFF
--- a/sanity-cli
+++ b/sanity-cli
@@ -880,7 +880,6 @@ def shell_cmd(args):
          
     # Get user
     env = get_project_env(project_name)
-    env = get_project_env(project_name)
     user = args.user if args.user else env.get("HOST_USER", "developer") 
     
     print_info(f"Entering shell for {project_name} ({container_name}) as {user}...")

--- a/sanity-cli
+++ b/sanity-cli
@@ -527,7 +527,7 @@ def get_project_env(project_name):
             
         # If we are here, container exists. Get Env.
         try:
-            out = run_command(f"docker inspect -f '{{{{range .Config.Env}}}}{{println .}}{{{{end}}}}' {container_name}", capture=True, check=False)
+            out = run_command(f"docker inspect -f '{{{{range .Config.Env}}}}{{{{println .}}}}{{{{end}}}}' {container_name}", capture=True, check=False)
             if not out: continue
             
             env_map = {}


### PR DESCRIPTION
Also fixes a small code-duplication: shell_cmd() called get_project_env() twice in a row