### PR TITLE
Allow selecting shell (zsh or bash) when running "sanity-cli shell"

### DIFF
--- a/sanity-cli
+++ b/sanity-cli
@@ -906,15 +906,15 @@ def shell_cmd(args):
     env = get_project_env(project_name)
     user = args.user if args.user else env.get("HOST_USER", "developer") 
     
-    print_info(f"Entering shell for {project_name} ({container_name}) as {user}...")
+    print_info(f"Entering shell for {project_name} ({container_name}) as {user} ({args.shell})...")
     
-    # Try zsh first, then bash
-    cmd = f"docker exec -it -u {user} {container_name} zsh"
+    # Try user-selected shell (zsh) first, then bash as fallback
+    cmd = f"docker exec -it -u {user} {container_name} {args.shell}"
     try:
         # Use simple os.system or subprocess.call to ensure TTY builds correctly
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:
-        print_warning("zsh failed, falling back to bash...")
+        print_warning(f"{args.shell} failed, falling back to bash...")
         cmd = f"docker exec -it -u {user} {container_name} bash"
         subprocess.call(cmd, shell=True)
 
@@ -1393,6 +1393,7 @@ def main():
     parser_shell = subparsers.add_parser("shell", help="Enter container shell")
     parser_shell.add_argument("--name", "-n", default="sanity-gravity", help="Project name")
     parser_shell.add_argument("--user", "-u", default=None, help="User to login as (default: developer)")
+    parser_shell.add_argument("--shell", "-s", default="zsh", choices=["zsh", "bash"], help="Shell to use (default: zsh)")
     parser_shell.set_defaults(func=shell_cmd)
 
     # Open Command

--- a/sanity-cli
+++ b/sanity-cli
@@ -906,17 +906,29 @@ def shell_cmd(args):
     env = get_project_env(project_name)
     user = args.user if args.user else env.get("HOST_USER", "developer") 
     
-    print_info(f"Entering shell for {project_name} ({container_name}) as {user} ({args.shell})...")
+    print_info(f"Entering shell for {project_name} ({container_name}) as {user}...")
     
-    # Try user-selected shell (zsh) first, then bash as fallback
-    cmd = f"docker exec -it -u {user} {container_name} {args.shell}"
+    if 'use' not in args:
+        # user didn't specify a shell, so use zsh as default, and fallback to bash if zsh fails
+        shell = 'zsh'
+        fallback_to_bash = True
+    else:
+        # use user specified shell, and don't fallback
+        shell = args.use
+        fallback_to_bash = False
+
+    cmd = f"docker exec -it -u {user} {container_name} {shell}"
     try:
         # Use simple os.system or subprocess.call to ensure TTY builds correctly
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:
-        print_warning(f"{args.shell} failed, falling back to bash...")
-        cmd = f"docker exec -it -u {user} {container_name} bash"
-        subprocess.call(cmd, shell=True)
+        if fallback_to_bash:
+            print_warning(f"{shell} failed, falling back to bash...")
+            cmd = f"docker exec -it -u {user} {container_name} bash"
+            subprocess.call(cmd, shell=True)
+        else:
+            print_error(f"{shell} failed. Specify the --use parameter to pick another shell.")
+
 
 def open_cmd(args):
     """Opens the active project's web interface."""
@@ -1393,7 +1405,7 @@ def main():
     parser_shell = subparsers.add_parser("shell", help="Enter container shell")
     parser_shell.add_argument("--name", "-n", default="sanity-gravity", help="Project name")
     parser_shell.add_argument("--user", "-u", default=None, help="User to login as (default: developer)")
-    parser_shell.add_argument("--shell", "-s", default="zsh", choices=["zsh", "bash"], help="Shell to use (default: zsh)")
+    parser_shell.add_argument("--use", default=argparse.SUPPRESS, choices=["zsh", "bash"], help="Shell to use (default: zsh, with fallback to bash)", )
     parser_shell.set_defaults(func=shell_cmd)
 
     # Open Command

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -1,4 +1,6 @@
+import argparse
 import pytest
+import subprocess
 import sys
 import os
 import importlib.util
@@ -229,17 +231,15 @@ class TestNewCommands:
     def test_shell_command(self, mock_check_call, mock_run):
         # Mock finding container
         mock_run.return_value = "true" # docker inspect running
-        
-        args = MagicMock()
-        args.name = "sanity-gravity"
-        args.user = None # Default behavior
-        
+
+        args = argparse.Namespace(name="sanity-gravity", user=None)
+
         with patch("sanity_cli.get_active_projects", return_value=["sanity-gravity"]):
             sanity_cli.shell_cmd(args)
-            
+
             # Check if docker exec was called
             # We assume it finds sanity-gravity-core-1 (first in VARIANTS)
-            # developer is default user
+            # developer is default user, zsh is default shell
             expected_cmd = "docker exec -it -u developer sanity-gravity-core-1 zsh"
             mock_check_call.assert_called_with(expected_cmd, shell=True)
 
@@ -247,18 +247,68 @@ class TestNewCommands:
     @patch("subprocess.check_call")
     def test_shell_command_with_user(self, mock_check_call, mock_run):
         # Mock finding container
-        mock_run.return_value = "true" 
-        
-        args = MagicMock()
-        args.name = "sanity-gravity"
-        args.user = "root" # Custom user
-        
+        mock_run.return_value = "true"
+
+        args = argparse.Namespace(name="sanity-gravity", user="root")
+
         with patch("sanity_cli.get_active_projects", return_value=["sanity-gravity"]):
             sanity_cli.shell_cmd(args)
-            
+
             # Verify user passed to docker exec
             expected_cmd = "docker exec -it -u root sanity-gravity-core-1 zsh"
             mock_check_call.assert_called_with(expected_cmd, shell=True)
+
+    @patch("sanity_cli.run_command")
+    @patch("subprocess.check_call")
+    def test_shell_command_with_use_bash(self, mock_check_call, mock_run):
+        # User explicitly selects bash via --use
+        mock_run.return_value = "true"
+
+        args = argparse.Namespace(name="sanity-gravity", user=None, use="bash")
+
+        with patch("sanity_cli.get_active_projects", return_value=["sanity-gravity"]):
+            sanity_cli.shell_cmd(args)
+
+            expected_cmd = "docker exec -it -u developer sanity-gravity-core-1 bash"
+            mock_check_call.assert_called_with(expected_cmd, shell=True)
+
+    @patch("sanity_cli.run_command")
+    @patch("subprocess.check_call")
+    @patch("subprocess.call")
+    def test_shell_command_zsh_fallback_to_bash(self, mock_call, mock_check_call, mock_run):
+        # No --use specified: zsh fails, should fall back to bash
+        mock_run.return_value = "true"
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, "zsh")
+
+        args = argparse.Namespace(name="sanity-gravity", user=None)
+
+        with patch("sanity_cli.get_active_projects", return_value=["sanity-gravity"]):
+            sanity_cli.shell_cmd(args)
+
+            mock_check_call.assert_any_call(
+                "docker exec -it -u developer sanity-gravity-core-1 zsh", shell=True
+            )
+            mock_call.assert_called_once_with(
+                "docker exec -it -u developer sanity-gravity-core-1 bash", shell=True
+            )
+
+    @patch("sanity_cli.run_command")
+    @patch("subprocess.check_call")
+    @patch("subprocess.call")
+    def test_shell_command_no_fallback_when_use_specified(self, mock_call, mock_check_call, mock_run):
+        # --use specified: failure should NOT fall back to bash
+        mock_run.return_value = "true"
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, "zsh")
+
+        args = argparse.Namespace(name="sanity-gravity", user=None, use="zsh")
+
+        with patch("sanity_cli.get_active_projects", return_value=["sanity-gravity"]):
+            sanity_cli.shell_cmd(args)
+
+            mock_check_call.assert_any_call(
+                "docker exec -it -u developer sanity-gravity-core-1 zsh", shell=True
+            )
+            mock_call.assert_not_called()
 
     @patch("sanity_cli.run_command")
     @patch("webbrowser.open")


### PR DESCRIPTION
Add optional --shell argument to script, with default being zsh