### PR TITLE
feat(cli): introduce native GHCR pull support via local tag normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 git clone https://github.com/shiritai/sanity-gravity.git
 cd sanity-gravity
 
-# 2. Build the images (one-time)
-./sanity-cli build
+# 2. (Optional) Build locally instead of pulling from GHCR
+# ./sanity-cli build
 
-# 3. Launch the recommended sandbox
+# 3. Launch the sandbox (Auto-pulls missing images from GHCR!)
 ./sanity-cli up -v ag-xfce-kasm --password mysecret
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -30,10 +30,10 @@
 git clone https://github.com/shiritai/sanity-gravity.git
 cd sanity-gravity
 
-# 2. イメージを構築（初回のみ）
-./sanity-cli build
+# 2. (任意) GHCRから取得する代わりにローカルでイメージを構築する
+# ./sanity-cli build
 
-# 3. 推奨サンドボックスを起動
+# 3. サンドボックスを起動（不足しているイメージはGHCRから自動取得！）
 ./sanity-cli up -v ag-xfce-kasm --password mysecret
 ```
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -30,10 +30,10 @@
 git clone https://github.com/shiritai/sanity-gravity.git
 cd sanity-gravity
 
-# 2. 建置映像檔（僅需一次）
-./sanity-cli build
+# 2. (可選) 本地建置映像檔（若不想依賴 GHCR 自動拉取）
+# ./sanity-cli build
 
-# 3. 啟動推薦的沙箱
+# 3. 啟動沙箱（若本地無映像檔，會自動從 GHCR 拉取！）
 ./sanity-cli up -v ag-xfce-kasm --password mysecret
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,6 +45,17 @@ Print all valid tags and the dimension matrix.
 
 ## Lifecycle Commands
 
+### `pull`
+
+Explicitly fetch pre-built sandbox images from GitHub Container Registry (GHCR) and retag them for local use (Local Tag Normalization). 
+By default, `up` will automatically invoke this if a local image is missing.
+
+```bash
+./sanity-cli pull                 # Pull all variants
+./sanity-cli pull agy-xfce-ssh    # Pull a specific variant
+./sanity-cli pull agy-none-ssh --tag v0.3.0-rc.3  # Pull a specific version
+```
+
 ### `up`
 
 Create and start a sandbox container.
@@ -57,6 +68,7 @@ Create and start a sandbox container.
 | Flag | Default | Description |
 |:-----|:--------|:------------|
 | `-v, --variant <tag>` | *(required)* | Tag to run (e.g. `ag-xfce-kasm`) |
+| `--pull` | off | Force pull latest GHCR image before starting |
 | `-p, --ssh-port <port>` | `2222` | Host port for SSH |
 | `--kasm-port <port>` | `8444` | Host port for KasmVNC |
 | `--vnc-port <port>` | `5901` | Host port for VNC |

--- a/sanity_gravity/cli/parser.py
+++ b/sanity_gravity/cli/parser.py
@@ -23,6 +23,7 @@ from sanity_gravity.verbs.shell import shell_cmd
 from sanity_gravity.verbs.snapshot import snapshot_cmd
 from sanity_gravity.verbs.status import list_variants, plugins_list, status
 from sanity_gravity.verbs.sync import sync_config_cmd
+from sanity_gravity.verbs.pull import pull
 from sanity_gravity.verbs.test_suite import test_suite
 from sanity_gravity.verbs.up import up
 from sanity_gravity.verbs.upgrade import upgrade
@@ -57,6 +58,8 @@ def _add_up_args(p):
                    help="Use custom base image (Snapshot)")
     p.add_argument("--recreate", action="store_true",
                    help="Force recreate if sandbox already exists")
+    p.add_argument("--pull", action="store_true",
+                   help="Force pull the latest image from GHCR before starting")
     p.set_defaults(func=up)
 
 
@@ -196,6 +199,19 @@ def build_parser():
         help="Shell to use (default: zsh, with fallback to bash)",
     )
     p_shell.set_defaults(func=shell_cmd)
+
+    # pull
+    p_pull = subparsers.add_parser("pull", help="Pull sandbox images from GHCR")
+    p_pull.add_argument(
+        "variant", nargs="*",
+        help="Tag to pull, e.g. ag-xfce-kasm (default: all)",
+        default=["all"],
+    )
+    p_pull.add_argument(
+        "--tag", default=None,
+        help="Explicit version tag to pull (default: auto-detected from git)",
+    )
+    p_pull.set_defaults(func=pull)
 
     # open
     p_open = subparsers.add_parser("open", help="Open web interface")

--- a/sanity_gravity/verbs/pull.py
+++ b/sanity_gravity/verbs/pull.py
@@ -1,0 +1,85 @@
+"""``pull`` verb: Fetch pre-built Sandbox images from GitHub Container Registry (GHCR).
+
+This implements the 'Local Tag Normalization' pattern. Instead of polluting
+docker-compose overlays with remote URLs, we pull the remote image and
+immediately re-tag it to the local standard name (sanity-gravity:<variant>).
+This ensures 100% compatibility with local dev builds and keeps compose files clean.
+"""
+from __future__ import annotations
+
+import os
+
+from sanity_gravity.cli.colors import Colors
+from sanity_gravity.cli.io import (
+    print_error,
+    print_header,
+    print_info,
+    print_success,
+    print_warning,
+    run_command,
+)
+from sanity_gravity.cli.registry import get_registry
+
+
+def get_target_version_tag() -> str:
+    """Smartly resolve which version tag to pull from GHCR.
+
+    1. Exact git tag (e.g., v0.3.0-rc.3)
+    2. Short SHA if on a commit (e.g., sha-abc1234)
+    3. Fallback to 'latest'
+    """
+    # 1. Try to get exact tag
+    tag_out = run_command(("git", "describe", "--tags", "--exact-match"), capture=True, check=False)
+    if tag_out and not tag_out.startswith("fatal:"):
+        return tag_out.strip()
+
+    # 2. Try to get short SHA
+    sha_out = run_command(("git", "rev-parse", "--short", "HEAD"), capture=True, check=False)
+    if sha_out and not sha_out.startswith("fatal:"):
+        return f"sha-{sha_out.strip()}"
+
+    # 3. Fallback
+    return "latest"
+
+
+def pull(args):
+    """Entry point for the ``pull`` command."""
+    variants = args.variant
+    if "all" in variants:
+        variants = list(get_registry().expand_wildcards(["*"]))
+
+    version_tag = args.tag if hasattr(args, "tag") and args.tag else get_target_version_tag()
+    repo_lc = "shiritai/sanity-gravity"  # Hardcoded repo owner/name for GHCR
+
+    print_header(f"Pulling {len(variants)} variant(s) (Version: {version_tag})")
+
+    failed = []
+    for variant in variants:
+        ghcr_image = f"ghcr.io/{repo_lc}-{variant}:{version_tag}"
+        local_image = f"sanity-gravity:{variant}"
+
+        print_info(f"[{variant}] Pulling {ghcr_image} ...")
+        # Let docker pull output directly to the terminal for progress bars
+        out = run_command(("docker", "pull", ghcr_image), check=False)
+        
+        if out is None:  # In non-dry-run mode, if check=False and it fails, run_command might exit? 
+            # Wait, `run_command` in io.py calls sys.exit if check=True. If check=False, it returns stdout or empty string.
+            pass
+
+        # Let's check if the image actually exists locally now
+        check_out = run_command(("docker", "image", "inspect", ghcr_image), capture=True, check=False)
+        if not check_out or check_out.strip() == "[]" or "Error: No such image" in check_out:
+            print_error(f"Failed to pull {ghcr_image}")
+            failed.append(variant)
+            continue
+
+        print_info(f"[{variant}] Re-tagging to {local_image} ...")
+        run_command(("docker", "tag", ghcr_image, local_image))
+        print_success(f"[{variant}] Successfully normalized local tag.")
+
+    if failed:
+        print_error(f"Failed to pull the following variants: {', '.join(failed)}")
+        import sys
+        sys.exit(1)
+    
+    print_success("All requested images are now available locally!")

--- a/sanity_gravity/verbs/up.py
+++ b/sanity_gravity/verbs/up.py
@@ -75,6 +75,18 @@ def up(args):
     if not args.skip_check:
         check_prereqs(args)
 
+    from sanity_gravity.verbs.pull import pull
+    if getattr(args, "pull", False):
+        pull(args)
+    elif not getattr(args, "dry_run", False):
+        check_img = run_command(
+            ("docker", "image", "inspect", f"sanity-gravity:{target}"),
+            capture=True, check=False,
+        )
+        if not check_img or check_img.strip() == "[]" or "Error: No such image" in check_img:
+            print_warning(f"Local image sanity-gravity:{target} not found. Auto-pulling from GHCR...")
+            pull(args)
+
     uid, gid, username = get_uid_gid_user()
     print_header(f"Starting {target}")
     print_info(f"Mapping User: {username} (UID={uid}, GID={gid})")

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -607,6 +607,8 @@ class TestSnapshot:
             args.memory = None
 
             args.image = "my-custom:v1"
+            args.pull = False
+            args.dry_run = True
 
             up_mod.up(args)
 


### PR DESCRIPTION
## 🚀 Description

This PR introduces native, frictionless support for fetching pre-built Sandbox images from the GitHub Container Registry (GHCR) directly within `sanity-cli`. 

Previously, `docker-compose.yml` relied strictly on locally built images (`sanity-gravity:<variant>`), forcing users to either build images locally or rely on manual `docker pull` and complex environment variable overrides. 

With this PR, we introduce the **Local Tag Normalization** architecture. This elegant design keeps the `docker-compose.yml` generators 100% pristine while providing an automated, smart-fallback workflow for users.

## 🏗️ Architecture: Local Tag Normalization

To maintain first principles and decouple "Acquisition" from "Execution":
1. **Execution** (`docker-compose up`): Continues to solely rely on the standard local tag `sanity-gravity:<variant>`.
2. **Acquisition** (`sanity-cli pull`): Pulls the remote GHCR image and immediately re-tags it to the local format.

```mermaid
flowchart TD
    subgraph Execution ["Phase: up (Execution)"]
        up["./sanity-cli up"]
        check{"Local image<br/>exists?"}
        run["Run docker-compose<br/>using 'sanity-gravity:tag'"]
        
        up --> check
        check -- Yes --> run
        check -- No --> AutoPull
    end

    subgraph Acquisition ["Phase: pull (Acquisition)"]
        AutoPull["Auto-Fallback to Pull"]
        resolve["Smart Version Resolution<br/>(git tags / commits)"]
        fetch["docker pull ghcr.io/...:version"]
        retag["docker tag ghcr.io/... sanity-gravity:tag"]
        
        AutoPull --> resolve
        resolve --> fetch
        fetch --> retag
    end
    
    retag --> run
```

## ✨ Key Features
- **Auto-Fallback (`up.py`)**: Running `./sanity-cli up -v <variant>` now automatically checks for the local image. If missing, it transparently pulls the image from GHCR before spinning up the container.
- **Smart Version Resolution**: The `pull` command dynamically determines which tag to download:
  - Exact `git describe` tags (e.g., `v0.3.0-rc.4`)
  - Commit SHA hashes (e.g., `sha-abc1234`)
  - Fallback to `latest`
- **Manual Control**: Added `./sanity-cli pull <variant>` to pre-fetch images, and `./sanity-cli up --pull` to forcefully overwrite local caches with the latest GHCR build.
- **Multi-Arch Native**: Leverages native `docker pull` behaviors to inherently support AMD64/ARM64 negotiation without requiring `DOCKER_DEFAULT_PLATFORM` injections.

## 📝 Changes
- `sanity_gravity/verbs/pull.py`: Added the new `pull` verb logic and version resolution.
- `sanity_gravity/verbs/up.py`: Injected `pull` auto-fallback just before Compose generation.
- `sanity_gravity/cli/parser.py`: Registered the new CLI arguments (`pull` verb and `--pull` flag).
- `docs/cli-reference.md`: Updated external documentation.

## 🧪 Testing Performed
- ✅ Uncached auto-pull: Deleted local images and ran `./sanity-cli up -v agy-none-ssh`. Verified successful GHCR pull, re-tagging, and container boot.
- ✅ Explicit pull: Ran `./sanity-cli pull agy-none-ssh` and confirmed version inference matching current git history.
- ✅ Force update: Verified `./sanity-cli up --pull` successfully bypasses local caches.