### PR TITLE
fix: chrome-cleanup robustness

### DIFF
--- a/plugins/agents/ag/rootfs/usr/local/bin/chrome-cleanup.sh
+++ b/plugins/agents/ag/rootfs/usr/local/bin/chrome-cleanup.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 # chrome-cleanup.sh
 # Shared cleanup logic for Chrome & Antigravity Agent to ensure Snapshot stability.
 
 # 1. Standard Locks (Prevent "Profile in use")
+# Resolve Chrome config directory for the current user
+CHROME_CONFIG="${HOME}/.config/google-chrome"
+if [ ! -d "$CHROME_CONFIG" ]; then
+    CHROME_CONFIG="${HOME}/.config/chromium"
+fi
 rm -f "$CHROME_CONFIG/SingletonLock"
 rm -f "$CHROME_CONFIG/SingletonSocket"
 rm -f "$CHROME_CONFIG/SingletonCookie"
@@ -29,7 +35,7 @@ rm -rf "$CHROME_CONFIG/GrShaderCache"
 rm -rf "$CHROME_CONFIG/Default/GPUCache"
 
 # 5. IPC & Shared Memory Debris in /tmp
-find /tmp -name ".org.chromium.Chromium*" -user $USER -delete 2>/dev/null || true
+find /tmp -name ".org.chromium.Chromium*" -user "$USER" -delete 2>/dev/null || true
 
 # 6. Antigravity Singleton Sockets (Prevent Stale Locks on Restart)
 # Only clean these up at container/desktop startup to avoid interfering

--- a/plugins/agents/ag/rootfs/usr/local/bin/chrome-cleanup.sh
+++ b/plugins/agents/ag/rootfs/usr/local/bin/chrome-cleanup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 # chrome-cleanup.sh
 # Shared cleanup logic for Chrome & Antigravity Agent to ensure Snapshot stability.
 
@@ -35,7 +34,7 @@ rm -rf "$CHROME_CONFIG/GrShaderCache"
 rm -rf "$CHROME_CONFIG/Default/GPUCache"
 
 # 5. IPC & Shared Memory Debris in /tmp
-find /tmp -name ".org.chromium.Chromium*" -user "$USER" -delete 2>/dev/null || true
+find /tmp -name ".org.chromium.Chromium*" -user "${USER:-$(id -un)}" -delete 2>/dev/null || true
 
 # 6. Antigravity Singleton Sockets (Prevent Stale Locks on Restart)
 # Only clean these up at container/desktop startup to avoid interfering
@@ -45,4 +44,4 @@ rm -f "$HOME/.config/Antigravity/SingletonSocket"
 rm -f "$HOME/.config/Antigravity/SingletonCookie"
 rm -f "$HOME/.config/Antigravity/singleton-cookie"
 
-echo "$(date): [chrome-cleanup] Cleanup completed for user $USER" >> /tmp/chrome-cleanup.log
+echo "$(date): [chrome-cleanup] Cleanup completed for user ${USER:-$(id -un)}" >> /tmp/chrome-cleanup.log

--- a/plugins/connectors/vnc/startup.sh
+++ b/plugins/connectors/vnc/startup.sh
@@ -5,7 +5,9 @@ set -e
 VNC_RESOLUTION=${VNC_RESOLUTION}
 VNC_DEPTH=${VNC_DEPTH}
 VNC_PW=${VNC_PW}
-# Dynamic HOME
+# Dynamic identity (parity with kasm/startup.sh; keeps USER exported for
+# sourced helpers like chrome-cleanup.sh)
+export USER=${USER}
 export HOME=${HOME}
 
 # Cleanup locks


### PR DESCRIPTION
Part of #21. This PR hardens the chrome-cleanup script by adding strict bash mode, dynamically resolving the Chrome config directory, and preventing variable word splitting.