### PR TITLE
feat(desktop): add cinnamon plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Every image is described by a tag: **`{agent}-{desktop}-{connector}`**. Pick one
 
 > **Heads-up:** `gc` (Gemini CLI) lost its free tier on 2026-06-18 and now requires a paid Gemini API key / Code Assist license. New users should prefer **`agy`** (Antigravity CLI), Google's official successor — already shipped here.
 
-There are **23 valid combinations** in total. See [Modular Tag System](docs/tags.md) for the full matrix, dimension model, and constraint rules.
+There are **41 valid combinations** in total. See [Modular Tag System](docs/tags.md) for the full matrix, dimension model, and constraint rules.
 
 Missing your favorite agent? Adding one takes a manifest plus a Dockerfile - see [Bring Your Own Agent](docs/bring-your-own-agent.md).
 
@@ -240,7 +240,10 @@ sanity-gravity/
 │   │   ├── agents/             # ag (Antigravity), agy (Antigravity CLI), gc (Gemini CLI), cc (Claude Code), cx (OpenAI Codex), oc (OpenCode)
 │   │   └── connectors/         # kasm (KasmVNC), vnc (TigerVNC), ssh
 │   └── rootfs/                 # Shared overlay (entrypoint, gravity-cli, supervisor configs)
-├── lib/                        # Proxy manager module
+├── plugins/                    # Manifest-driven plugins
+│   ├── desktops/               #   xfce, cinnamon, none
+│   ├── agents/                 #   ag, agy, gc, cc, cx, oc
+│   └── connectors/             #   kasm (KasmVNC), vnc (TigerVNC), ssh
 ├── config/                     # Runtime-generated docker-compose files (git-ignored)
 ├── tests/                      # Pytest integration suite
 ├── workspace/                  # Default bind-mounted workspace

--- a/README_ja.md
+++ b/README_ja.md
@@ -108,7 +108,7 @@ AI エージェントは任意のコードを実行します。たった一度�
 
 > **注意:** `gc`（Gemini CLI）は 2026-06-18 に無料枠が終了し、有料の Gemini API キー / Code Assist ライセンスが必要になりました。新規ユーザーは Google 公式の後継である **`agy`**（Antigravity CLI、本プロジェクトに同梱済み）を推奨します。
 
-合計 **23 の有効な組み合わせ** があります。完全なマトリックス、次元モデル、制約ルールについては [モジュラータグシステム](docs/tags.md) をご参照ください。
+合計 **41 の有効な組み合わせ** があります。完全なマトリックス、次元モデル、制約ルールについては [モジュラータグシステム](docs/tags.md) をご参照ください。
 
 使いたいエージェントが未搭載でも、manifest と Dockerfile の 2 ファイルで追加できます — [Bring Your Own Agent ガイド](docs/bring-your-own-agent.md) をご参照ください。
 
@@ -238,7 +238,10 @@ sanity-gravity/
 │   │   ├── agents/             # ag（Antigravity）、agy（Antigravity CLI）、gc（Gemini CLI）、cc（Claude Code）、cx（OpenAI Codex）、oc（OpenCode）
 │   │   └── connectors/         # kasm（KasmVNC）、vnc（TigerVNC）、ssh
 │   └── rootfs/                 # 共有オーバーレイ（entrypoint、gravity-cli、supervisor 設定）
-├── lib/                        # Proxy Manager モジュール
+├── plugins/                    # マニフェスト駆動プラグイン
+│   ├── desktops/               #   xfce、cinnamon、none
+│   ├── agents/                 #   ag、agy、gc、cc、cx、oc
+│   └── connectors/             #   kasm（KasmVNC）、vnc（TigerVNC）、ssh
 ├── config/                     # 動的生成される docker-compose ファイル（git-ignored）
 ├── tests/                      # Pytest 統合テストスイート
 ├── workspace/                  # デフォルトのマウント先ワークスペース

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -108,7 +108,7 @@ AI 代理會執行任意程式碼。一個意外的 `rm -rf /` 就足以讓你�
 
 > **注意：** `gc`（Gemini CLI）免費方案已於 2026-06-18 終止，現需付費 Gemini API key / Code Assist 授權。新使用者建議改用 **`agy`**（Antigravity CLI）—— Google 官方接替者，本專案已內建。
 
-共有 **23 個有效組合**。完整矩陣、維度模型與約束規則請參考 [模組化標籤系統](docs/tags.md)。
+共有 **41 個有效組合**。完整矩陣、維度模型與約束規則請參考 [模組化標籤系統](docs/tags.md)。
 
 想用的代理還沒內建？新增一個只需要 manifest 加 Dockerfile —— 請參考 [自帶 Agent 指南](docs/bring-your-own-agent.md)。
 
@@ -238,7 +238,10 @@ sanity-gravity/
 │   │   ├── agents/             # ag（Antigravity）、agy（Antigravity CLI）、gc（Gemini CLI）、cc（Claude Code）、cx（OpenAI Codex）、oc（OpenCode）
 │   │   └── connectors/         # kasm（KasmVNC）、vnc（TigerVNC）、ssh
 │   └── rootfs/                 # 共用覆疊層（entrypoint、gravity-cli、supervisor 設定）
-├── lib/                        # Proxy Manager 模組
+├── plugins/                    # 清單驅動外掛
+│   ├── desktops/               #   xfce、cinnamon、none
+│   ├── agents/                 #   ag、agy、gc、cc、cx、oc
+│   └── connectors/             #   kasm（KasmVNC）、vnc（TigerVNC）、ssh
 ├── config/                     # 動態產生的 docker-compose 檔（git-ignored）
 ├── tests/                      # Pytest 整合測試套件
 ├── workspace/                  # 預設掛載的工作目錄

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,17 @@ The base image (`Dockerfile.base`) installs `supervisord` as the process manager
 5. Starts D-Bus (if installed), cleans stale locks, regenerates SSH host keys
 6. Launches `supervisord` and traps `SIGTERM` for graceful shutdown
 
+## Desktop Session Launcher Contract
+
+The VNC-family connectors (`kasm`, `vnc`) start a graphical session at
+container start. Desktop plugins own that launcher contract: each GUI
+desktop ships a `/usr/local/bin/desktop-session` entry point, so the
+connectors can invoke one stable command and the browser/VNC window always
+shows the desktop environment. `xfce` ships the contract as a one-liner
+(`exec startxfce4`); `cinnamon` (a GNOME fork) launches via
+`cinnamon-session`. Headless `none` tags have no desktop and no session
+file.
+
 ## Filesystem Layout
 
 ```
@@ -100,6 +111,9 @@ sandbox/
 plugins/                        # Manifest-driven extension point (PR #6)
 ├── desktops/
 │   ├── xfce/                   # Layer 2: XFCE4 desktop
+│   │   ├── manifest.toml       #   provides=[display]
+│   │   └── Dockerfile
+│   ├── cinnamon/               # Layer 2: Cinnamon desktop
 │   │   ├── manifest.toml       #   provides=[display]
 │   │   └── Dockerfile
 │   └── none/                   # Layer 2: headless (no-op)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,7 +16,7 @@ Verifies that Docker and Docker Compose (v2.0+) are installed and the Docker dae
 
 ### `build [tag...]`
 
-Build sandbox images. Defaults to building all 19 official tags.
+Build sandbox images. Defaults to building all 34 official tags.
 
 ```bash
 ./sanity-cli build              # Build all images

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -29,6 +29,7 @@ Whether a graphical desktop environment is included.
 | Slug | Name | Has GUI |
 |:-----|:-----|:--------|
 | `xfce` | XFCE | Yes — full XFCE4 desktop with window manager |
+| `cinnamon` | Cinnamon | Yes — Cinnamon desktop environment |
 | `none` | Headless | No — `DISPLAY` is unset, minimal footprint |
 
 ### Connectors
@@ -45,36 +46,54 @@ How you connect to the running container.
 
 Not all combinations are valid. Two rules are enforced:
 
-1. **GUI connectors require a GUI desktop**: `kasm` and `vnc` can only pair with `xfce` (not `none`).
-2. **GUI agents require a GUI desktop**: `ag` (Antigravity IDE) can only pair with `xfce` (not `none`).
+1. **GUI connectors require a GUI desktop**: `kasm` and `vnc` can only pair with `xfce` or `cinnamon` (not `none`).
+2. **GUI agents require a GUI desktop**: `ag` (Antigravity IDE) can only pair with `xfce` or `cinnamon` (not `none`).
 
 These rules are enforced by `sanity-cli` at build time and run time.
 
-## All Valid Tags (23)
+## All Valid Tags (41)
 
 Listed in the same order as `./sanity-cli list` (agents sorted alphabetically).
 
 | Tag | Agent | Desktop | Connector | Use Case |
 |:----|:------|:--------|:----------|:---------|
+| `ag-cinnamon-kasm` | Antigravity | Cinnamon | KasmVNC | Full IDE sandbox via browser |
+| `ag-cinnamon-ssh` | Antigravity | Cinnamon | SSH | Full IDE sandbox, SSH-only access |
+| `ag-cinnamon-vnc` | Antigravity | Cinnamon | TigerVNC | Full IDE sandbox via legacy VNC client |
 | **`ag-xfce-kasm`** | Antigravity | XFCE | KasmVNC | Full IDE sandbox via browser **(default)** |
 | `ag-xfce-ssh` | Antigravity | XFCE | SSH | Full IDE sandbox, SSH-only access |
 | `ag-xfce-vnc` | Antigravity | XFCE | TigerVNC | Full IDE sandbox via legacy VNC client |
+| `agy-cinnamon-kasm` | Antigravity CLI | Cinnamon | KasmVNC | Antigravity CLI with Cinnamon desktop |
+| `agy-cinnamon-ssh` | Antigravity CLI | Cinnamon | SSH | Antigravity CLI with GUI, SSH-only access |
+| `agy-cinnamon-vnc` | Antigravity CLI | Cinnamon | TigerVNC | Antigravity CLI with legacy VNC |
 | `agy-none-ssh` | Antigravity CLI | Headless | SSH | Lightweight Antigravity CLI terminal |
 | `agy-xfce-kasm` | Antigravity CLI | XFCE | KasmVNC | Antigravity CLI with browser desktop |
 | `agy-xfce-ssh` | Antigravity CLI | XFCE | SSH | Antigravity CLI with GUI, SSH-only access |
 | `agy-xfce-vnc` | Antigravity CLI | XFCE | TigerVNC | Antigravity CLI with legacy VNC |
+| `cc-cinnamon-kasm` | Claude Code | Cinnamon | KasmVNC | Claude Code with Cinnamon desktop |
+| `cc-cinnamon-ssh` | Claude Code | Cinnamon | SSH | Claude Code with GUI, SSH-only access |
+| `cc-cinnamon-vnc` | Claude Code | Cinnamon | TigerVNC | Claude Code with legacy VNC |
 | `cc-none-ssh` | Claude Code | Headless | SSH | Lightweight Claude Code terminal |
 | `cc-xfce-kasm` | Claude Code | XFCE | KasmVNC | Claude Code with browser desktop |
 | `cc-xfce-ssh` | Claude Code | XFCE | SSH | Claude Code with GUI, SSH-only access |
 | `cc-xfce-vnc` | Claude Code | XFCE | TigerVNC | Claude Code with legacy VNC |
+| `cx-cinnamon-kasm` | OpenAI Codex | Cinnamon | KasmVNC | Codex with Cinnamon desktop |
+| `cx-cinnamon-ssh` | OpenAI Codex | Cinnamon | SSH | Codex with GUI, SSH-only access |
+| `cx-cinnamon-vnc` | OpenAI Codex | Cinnamon | TigerVNC | Codex with legacy VNC |
 | `cx-none-ssh` | OpenAI Codex | Headless | SSH | Lightweight Codex terminal |
 | `cx-xfce-kasm` | OpenAI Codex | XFCE | KasmVNC | Codex with browser desktop |
 | `cx-xfce-ssh` | OpenAI Codex | XFCE | SSH | Codex with GUI, SSH-only access |
 | `cx-xfce-vnc` | OpenAI Codex | XFCE | TigerVNC | Codex with legacy VNC |
+| `gc-cinnamon-kasm` | Gemini CLI | Cinnamon | KasmVNC | Gemini with Cinnamon desktop |
+| `gc-cinnamon-ssh` | Gemini CLI | Cinnamon | SSH | Gemini with GUI, SSH-only access |
+| `gc-cinnamon-vnc` | Gemini CLI | Cinnamon | TigerVNC | Gemini with legacy VNC |
 | `gc-none-ssh` | Gemini CLI | Headless | SSH | Lightweight Gemini terminal |
 | `gc-xfce-kasm` | Gemini CLI | XFCE | KasmVNC | Gemini with browser desktop |
 | `gc-xfce-ssh` | Gemini CLI | XFCE | SSH | Gemini with GUI, SSH-only access |
 | `gc-xfce-vnc` | Gemini CLI | XFCE | TigerVNC | Gemini with legacy VNC |
+| `oc-cinnamon-kasm` | OpenCode | Cinnamon | KasmVNC | OpenCode with Cinnamon desktop |
+| `oc-cinnamon-ssh` | OpenCode | Cinnamon | SSH | OpenCode with GUI, SSH-only access |
+| `oc-cinnamon-vnc` | OpenCode | Cinnamon | TigerVNC | OpenCode with legacy VNC |
 | `oc-none-ssh` | OpenCode | Headless | SSH | Lightweight OpenCode terminal |
 | `oc-xfce-kasm` | OpenCode | XFCE | KasmVNC | OpenCode with browser desktop |
 | `oc-xfce-ssh` | OpenCode | XFCE | SSH | OpenCode with GUI, SSH-only access |

--- a/plugins/desktops/cinnamon/Dockerfile
+++ b/plugins/desktops/cinnamon/Dockerfile
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE=sanity-gravity:_base
+FROM ${BASE_IMAGE}
+
+# Install Cinnamon Desktop and Core Utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # --- Cinnamon Core & Session ---
+    cinnamon-core \
+    # --- Core Utilities (replaces XFCE-Tools) ---
+    gnome-terminal \
+    file-roller \
+    # --- Shared X11, DBus & System Utilities ---
+    dbus \
+    dbus-x11 \
+    x11-utils \
+    x11-xserver-utils \
+    xdotool \
+    libgl1-mesa-dri \
+    && apt-get autoremove -y && \
+    rm -rf /usr/share/doc/* /usr/share/info/* /usr/share/lintian/* /usr/share/man/* \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Register standard desktop session launcher contract. Identify the session
+# as Cinnamon/x11 so Cinnamon components behave correctly: muffin avoids the
+# "Unsupported session type" warning, nemo-desktop/polkit recognize the DE
+# (otherwise nemo logs "session is not cinnamon" and skips desktop handling).
+RUN echo '#!/bin/sh\nexec env XDG_CURRENT_DESKTOP=Cinnamon DESKTOP_SESSION=cinnamon XDG_SESSION_DESKTOP=cinnamon XDG_SESSION_TYPE=x11 cinnamon-session' > /usr/local/bin/desktop-session \
+    && chmod +x /usr/local/bin/desktop-session
+

--- a/plugins/desktops/cinnamon/manifest.toml
+++ b/plugins/desktops/cinnamon/manifest.toml
@@ -1,0 +1,15 @@
+[plugin]
+slug = "cinnamon"
+name = "cinnamon"
+kind = "desktop"
+api_version = "1"
+tier = "official"
+
+[capabilities]
+provides = ["display"]
+requires = []
+
+[build]
+dockerfile = "Dockerfile"
+
+

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -42,6 +42,20 @@ from sanity_gravity.verbs.build import (  # noqa: E402
 )
 
 
+def _running_filter(container_name: str):
+    """run_command mock: report only ``container_name`` as running.
+
+    Realistic stand-in for the verbs' scan over VALID_TAGS — the mock
+    returns "true" only for the targeted container so the scan is not
+    sensitive to the (alphabetical) ordering of valid tags.
+    """
+
+    def _fake_run(cmd, **_kw):
+        return "true" if container_name in " ".join(cmd) else "false"
+
+    return _fake_run
+
+
 class TestDimensionConstraints:
     """Tests for dimension-based tag constraint filtering."""
 
@@ -72,12 +86,12 @@ class TestDimensionConstraints:
             assert d == "none"
             assert c == "ssh"
 
-    def test_all_ag_tags_have_xfce(self):
-        """Every ag tag must use xfce desktop."""
+    def test_all_ag_tags_have_gui_desktop(self):
+        """Every default-base ag tag must use a GUI desktop (xfce/cinnamon)."""
         ag_tags = [t for t in VALID_TAGS if t.startswith("ag-")]
-        assert len(ag_tags) == 3
+        assert len(ag_tags) == 6
         for tag in ag_tags:
-            assert "-xfce-" in tag
+            assert "-xfce-" in tag or "-cinnamon-" in tag
 
     def test_no_headless_gui_connector_in_valid_tags(self):
         """No *-none-kasm/vnc should appear in VALID_TAGS."""
@@ -406,7 +420,7 @@ class TestNewCommands:
     @patch("sanity_gravity.verbs.shell.run_command")
     @patch("subprocess.check_call")
     def test_shell_command(self, mock_check_call, mock_run, mock_env):
-        mock_run.return_value = "true"
+        mock_run.side_effect = _running_filter("ag-xfce-kasm-1")
 
         args = argparse.Namespace(name="sanity-gravity", user=None)
 
@@ -424,7 +438,7 @@ class TestNewCommands:
     @patch("sanity_gravity.verbs.shell.run_command")
     @patch("subprocess.check_call")
     def test_shell_command_with_user(self, mock_check_call, mock_run, mock_env):
-        mock_run.return_value = "true"
+        mock_run.side_effect = _running_filter("ag-xfce-kasm-1")
 
         args = argparse.Namespace(name="sanity-gravity", user="root")
 
@@ -442,7 +456,7 @@ class TestNewCommands:
     @patch("sanity_gravity.verbs.shell.run_command")
     @patch("subprocess.check_call")
     def test_shell_command_with_use_bash(self, mock_check_call, mock_run, mock_env):
-        mock_run.return_value = "true"
+        mock_run.side_effect = _running_filter("ag-xfce-kasm-1")
 
         args = argparse.Namespace(name="sanity-gravity", user=None, use="bash")
 
@@ -463,7 +477,7 @@ class TestNewCommands:
     def test_shell_command_zsh_fallback_to_bash(
         self, mock_call, mock_check_call, mock_run, mock_env
     ):
-        mock_run.return_value = "true"
+        mock_run.side_effect = _running_filter("ag-xfce-kasm-1")
         mock_check_call.side_effect = subprocess.CalledProcessError(1, "zsh")
 
         args = argparse.Namespace(name="sanity-gravity", user=None)
@@ -490,7 +504,7 @@ class TestNewCommands:
     def test_shell_command_no_fallback_when_use_specified(
         self, mock_call, mock_check_call, mock_run, mock_env
     ):
-        mock_run.return_value = "true"
+        mock_run.side_effect = _running_filter("ag-xfce-kasm-1")
         mock_check_call.side_effect = subprocess.CalledProcessError(1, "zsh")
 
         args = argparse.Namespace(name="sanity-gravity", user=None, use="zsh")

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -40,6 +40,7 @@ PLUGINS_DIR = _REPO_ROOT / "plugins"
         ("agents", "gc"),
         ("agents", "cc"),
         ("desktops", "xfce"),
+        ("desktops", "cinnamon"),
         ("desktops", "none"),
         ("connectors", "kasm"),
         ("connectors", "vnc"),

--- a/tests/unit/test_oc_agent.py
+++ b/tests/unit/test_oc_agent.py
@@ -94,6 +94,7 @@ def test_oc_tags_enter_the_official_matrix():
 
     oc_tags = [t for t in OFFICIAL_TAGS if t.startswith("oc-")]
     assert sorted(oc_tags) == [
+        "oc-cinnamon-kasm", "oc-cinnamon-ssh", "oc-cinnamon-vnc",
         "oc-none-ssh", "oc-xfce-kasm", "oc-xfce-ssh", "oc-xfce-vnc",
     ]
     for t in oc_tags:

--- a/tests/unit/test_plugin_registry.py
+++ b/tests/unit/test_plugin_registry.py
@@ -36,7 +36,7 @@ def test_from_dir_loads_plugins(reg):
 
 def test_registered_slugs(reg):
     assert {"ag", "gc", "cc"}.issubset(set(reg.agents))
-    assert set(reg.desktops) == {"xfce", "none"}
+    assert set(reg.desktops) == {"xfce", "none", "cinnamon"}
     assert set(reg.connectors) == {"kasm", "vnc", "ssh"}
 
 

--- a/tests/unit/test_tiers.py
+++ b/tests/unit/test_tiers.py
@@ -135,7 +135,7 @@ class TestCliEnumeration:
         )
 
         gc_tags = [t for t in VALID_TAGS if t.startswith("gc-")]
-        assert len(gc_tags) == 4
+        assert len(gc_tags) == 7
         assert not any(t.startswith("gc-") for t in OFFICIAL_TAGS)
         # Everything else is untouched by gc's retirement.
         assert set(VALID_TAGS) - set(gc_tags) == set(OFFICIAL_TAGS)


### PR DESCRIPTION
Add the Cinnamon desktop environment as a second GUI desktop option. The matrix grows (41 valid / 34 official tags); the shared unit tests are extended in place: ag tags cover cinnamon, the oc matrix gains the cinnamon rows, the gc deprecation count tracks the new combos, and the registry assertion lists the new slug.