### PR TITLE
feat(connectors): bake KasmVNC TLS certs, sync VNC clipboard, tidy la…

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,22 @@ The base image (`Dockerfile.base`) installs `supervisord` as the process manager
 5. Starts D-Bus (if installed), cleans stale locks, regenerates SSH host keys
 6. Launches `supervisord` and traps `SIGTERM` for graceful shutdown
 
+## Desktop Session & Menu Entries
+
+The VNC-family connectors (`kasm`, `vnc`) write a per-container
+`~/.vnc/xstartup` that ends in
+`exec dbus-launch --exit-with-session /usr/local/bin/desktop-session`
+(when the desktop plugin ships that launcher — `xfce` does — with a
+fallback to `startxfce4` otherwise). `dbus-launch` guarantees a session
+bus, and the connectors also create `/run/user/$UID` / export
+`XDG_RUNTIME_DIR`, which systemd would normally provide at login. Before
+that `exec`, the xstartup additionally (a) runs `vncconfig -nowin &` so
+the X11 CLIPBOARD selection is bridged to the VNC/RFB clipboard in both
+directions (required by TigerVNC, also shipped by KasmVNC), and (b) merges
+the desktop's X resources from `/etc/X11/Xresources/*` via `xrdb`. Both
+steps are guarded so they are no-ops on desktops that ship neither tool
+nor resources. Headless `none` tags have no desktop and no session file.
+
 ## Filesystem Layout
 
 ```
@@ -139,6 +155,23 @@ plugins/                        # Manifest-driven extension point (PR #6)
         ├── manifest.toml
         └── Dockerfile
 ```
+
+### KasmVNC TLS certificate
+
+The `kasm` connector serves the browser desktop over HTTPS. Instead of the
+anonymous Debian snakeoil cert (which triggers *both* a hostname-mismatch and
+a trust error), the image bakes a long-lived development certificate at build
+time via `plugins/connectors/kasm/rootfs/usr/local/bin/gen-localhost-certs.sh`:
+
+- A server cert valid for `DNS:localhost` / `IP:127.0.0.1` (no hostname
+  warning), presented together with its signing CA as the chain.
+- A signing CA at `/etc/ssl/local/gravity-ca.pem`. Importing that CA **once**
+  into the browser/OS trust store silences the self-signed trust warning
+  entirely (e.g. on Linux: `openssl x509 -in <ca.pem> -out ca.crt` and import
+  into the browser certificate store, or `cp` it to `/usr/local/share/ca-certificates/`
+  + `update-ca-certificates`).
+- Certs are baked, not regenerated per container, so a single CA import keeps
+  working across container re-creations and image rebuilds.
 
 ### Adding a new plugin
 

--- a/plugins/connectors/kasm/Dockerfile
+++ b/plugins/connectors/kasm/Dockerfile
@@ -3,26 +3,42 @@ ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
 # Install KasmVNC
-# Using a fixed version for stability with SHA256 integrity verification
-ENV KASM_VERSION=1.4.0
+# Using a fixed version for stability with SHA256 integrity verification.
+# KasmVNC ships distro-specific .debs: noble (Ubuntu 24.04) and bookworm
+# (Debian 12) have different shared-library requirements, so the layer
+# picks the matching package from /etc/os-release at build time (the
+# same connector layer builds on both base images).
+ENV KASM_VERSION=1.5.0
 RUN arch=$(dpkg --print-architecture); \
-    KASM_DEB="kasmvncserver_noble_${KASM_VERSION}_${arch}.deb" && \
+    if grep -q "ID=debian" /etc/os-release; then KASM_DIST="bookworm"; else KASM_DIST="noble"; fi; \
+    KASM_DEB="kasmvncserver_${KASM_DIST}_${KASM_VERSION}_${arch}.deb" && \
     curl -L -O "https://github.com/kasmtech/KasmVNC/releases/download/v${KASM_VERSION}/${KASM_DEB}" && \
-    if [ "$arch" = "amd64" ]; then \
-        echo "12bac6014149c5fdee75f0d403785aaa3e5dd4ea222de73253a5d4181bc9567e  ${KASM_DEB}" | sha256sum -c -; \
-    else \
-        echo "120d9462cb5e917cad91a23f6cb0b780c06f701def40e900b29f996979200638  ${KASM_DEB}" | sha256sum -c -; \
-    fi && \
-    apt-get update && apt-get install -y "./${KASM_DEB}" ssl-cert && \
+    case "${KASM_DIST}_${arch}" in \
+        noble_amd64)    echo "f599fe02e2175b9817b6165f74a5d2bebdc73118dde9181ba3410963bed7ae1e  ${KASM_DEB}" | sha256sum -c - ;; \
+        noble_arm64)    echo "c9199cf4753208bfb69fd016a9780242bebfc43370cc38c97d61e90a3c783e04  ${KASM_DEB}" | sha256sum -c - ;; \
+        bookworm_amd64) echo "770fd3df51510beecc89666879d82faf411276e68c6e11df612f736b891b5f71  ${KASM_DEB}" | sha256sum -c - ;; \
+        bookworm_arm64) echo "aa83a1a6c9069d1a02239988b07a3a2a082a433042b4d4ee2b9e9f6b2df9643c  ${KASM_DEB}" | sha256sum -c - ;; \
+        *) echo "unsupported: ${KASM_DIST}_${arch}" >&2; exit 1 ;; \
+    esac && \
+    apt-get update && apt-get install -y "./${KASM_DEB}" ssl-cert openssl && \
     rm "${KASM_DEB}" && \
-    rm -f /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get autoremove -y && \
+    rm -rf /usr/share/doc/* /usr/share/info/* /usr/share/lintian/* /usr/share/man/* \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add Supervisor Config for Kasm
 COPY supervisord.conf /etc/supervisor/conf.d/kasm.conf
 
 # Inject entrypoint hooks
 COPY rootfs/ /
+
+# Bake a stable localhost CA + server certificate (see
+# /usr/local/bin/gen-localhost-certs.sh). The snakeoil package default is
+# anonymous and triggers both a hostname and a trust warning; our cert is
+# valid for localhost/127.0.0.1 and ships a CA that can be imported once into
+# the browser/OS trust store. Baked at build time (not regenerated per
+# container) so one CA import survives container re-creations.
+RUN /usr/local/bin/gen-localhost-certs.sh
 
 # Add Kasm Startup Script
 COPY startup.sh /usr/local/bin/kasm-startup.sh

--- a/plugins/connectors/kasm/rootfs/usr/local/bin/gen-localhost-certs.sh
+++ b/plugins/connectors/kasm/rootfs/usr/local/bin/gen-localhost-certs.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# gen-localhost-certs: bake a stable development CA + localhost server cert.
+#
+# KasmVNC serves the desktop over HTTPS using the certificate it finds at the
+# Debian snakeoil paths. The distro-generated snakeoil cert is anonymous, so
+# browsers reject it on both trust AND hostname (it has no Subject Alternative
+# Name for localhost). This script bakes a long-lived CA + server certificate
+# into the image at build time:
+#   - the server cert is valid for localhost / 127.0.0.1 (no hostname error),
+#   - the CA can be imported once into a browser / OS trust store to also
+#     silence the self-signed trust warning (see docs/architecture.md).
+# The certs are baked (NOT regenerated per container) so a single CA import
+# stays valid across container re-creations.
+set -e
+
+CA_DIR="/etc/ssl/local"
+CA_KEY="$CA_DIR/gravity-ca.key"
+CA_CERT="$CA_DIR/gravity-ca.pem"
+SERVER_KEY="/etc/ssl/private/ssl-cert-snakeoil.key"
+SERVER_PEM="/etc/ssl/certs/ssl-cert-snakeoil.pem"
+
+mkdir -p "$CA_DIR"
+
+# Development CA. Reuse an existing one so repeated builds keep the same
+# CA identity (an already-imported CA stays valid across image rebuilds).
+if [ ! -f "$CA_CERT" ]; then
+    openssl genrsa -out "$CA_KEY" 2048
+    chmod 600 "$CA_KEY"
+    openssl req -x509 -new -key "$CA_KEY" -sha256 -days 3650 \
+        -subj "/CN=Sanity Gravity Development CA" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" \
+        -out "$CA_CERT"
+fi
+
+# Server key + certificate signed by the CA, valid for localhost access.
+EXT_FILE="$(mktemp)"
+trap 'rm -f "$EXT_FILE"' EXIT
+cat > "$EXT_FILE" <<'EOF'
+basicConstraints=critical,CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+openssl genrsa -out "$SERVER_KEY" 2048
+chmod 600 "$SERVER_KEY"
+openssl req -new -key "$SERVER_KEY" -subj "/CN=localhost" -out "$CA_DIR/server.csr"
+openssl x509 -req -in "$CA_DIR/server.csr" \
+    -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+    -days 3650 -sha256 -extfile "$EXT_FILE" \
+    -out "$SERVER_PEM"
+
+# Present the chain (leaf + CA) so clients that trust the CA validate the leaf.
+cat "$CA_CERT" >> "$SERVER_PEM"
+
+# vncserver runs as the developer user, a member of the ssl-cert group.
+chmod 640 "$SERVER_KEY"
+chown root:ssl-cert "$SERVER_KEY" 2>/dev/null || true
+chmod 644 "$SERVER_PEM"
+rm -f "$CA_DIR/server.csr"

--- a/plugins/connectors/kasm/startup.sh
+++ b/plugins/connectors/kasm/startup.sh
@@ -5,9 +5,26 @@ set -e
 export USER=${USER}
 export HOME=${HOME}
 
-# Generate SSL certificate if missing (moved from Dockerfile for per-container uniqueness)
-if [ ! -f /etc/ssl/certs/ssl-cert-snakeoil.pem ]; then
-    sudo make-ssl-cert generate-default-snakeoil --force-overwrite
+# Cinnamon (a GNOME fork) requires a per-user runtime directory for its
+# session bus and dconf; on a normal login systemd creates /run/user/$UID
+# and exports XDG_RUNTIME_DIR, but in a container there is no systemd login.
+# Without it the session dies right after authentication -> black desktop
+# (see KasmVNC FAQ "Gnome Shows Black Screen").
+RUNTIME_DIR="/run/user/$(id -u)"
+if [ ! -d "$RUNTIME_DIR" ]; then
+    sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" "$RUNTIME_DIR"
+fi
+export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+
+# TLS certificate. The image bakes a localhost CA + server certificate at
+# /etc/ssl/certs/ssl-cert-snakeoil.pem (see gen-localhost-certs.sh) at build
+# time, so it is stable across container re-creations and a single CA import
+# into the browser/OS trust store keeps working. Only the group permission
+# needs (re)enforcing here in case the key lost it during an image commit:
+# vncserver runs as a member of the ssl-cert group.
+if [ -f /etc/ssl/private/ssl-cert-snakeoil.key ]; then
+    sudo chown root:ssl-cert /etc/ssl/private/ssl-cert-snakeoil.key
+    sudo chmod 640 /etc/ssl/private/ssl-cert-snakeoil.key
 fi
 
 # Cleanup locks
@@ -31,22 +48,49 @@ mkdir -p $HOME/.vnc
 echo -e "${HOST_PASSWORD}\n${HOST_PASSWORD}\n" | vncpasswd -u $USER -w
 # chmod 600 $HOME/.vnc/passwd
 
-# Setup xstartup for XFCE4
+# Setup xstartup for Desktop Session. The desktop-session launcher is owned
+# by the desktop plugin; wrapping it in dbus-launch guarantees a session bus
+# for the DE (Cinnamon requires one) and exports DBUS_SESSION_BUS_ADDRESS to
+# every app it spawns (nemo, terminals, ...).
+#
+# Before the session starts we (1) run vncconfig -nowin, which bridges the
+# X11 CLIPBOARD selection to the VNC/RFB clipboard so the browser can copy
+# and paste in both directions (required by TigerVNC; KasmVNC ships the same
+# tool), and (2) merge the desktop's X resources (xterm font + clipboard
+# selection, shipped by the openbox plugin) into the server. Both are guarded
+# so connectors work on desktops that ship neither.
 cat > $HOME/.vnc/xstartup <<EOF
 #!/bin/sh
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
-exec startxfce4
+if command -v vncconfig >/dev/null 2>&1; then
+    vncconfig -nowin &
+fi
+if command -v xrdb >/dev/null 2>&1 && [ -d /etc/X11/Xresources ]; then
+    for f in /etc/X11/Xresources/*; do
+        [ -f "\$f" ] && xrdb -merge "\$f"
+    done
+fi
+if [ -x /usr/local/bin/desktop-session ]; then
+    exec dbus-launch --exit-with-session /usr/local/bin/desktop-session
+else
+    exec dbus-launch --exit-with-session startxfce4
+fi
 EOF
 chmod +x $HOME/.vnc/xstartup
 
+# Mark the desktop environment as already selected so KasmVNC skips its
+# interactive DE picker (select-de.sh). That prompt reads from stdin and
+# would hang forever under supervisord, so the HTTPS listener never starts.
+touch $HOME/.vnc/.de-was-selected
+
 echo "Starting KasmVNC on port 8444..."
 # Start KasmVNC
-# -select-de xfce might be needed if xstartup isn't used, but xstartup is standard.
 exec /usr/bin/vncserver :1 \
     -depth 24 \
     -geometry 1920x1080 \
     -websocketPort 8444 \
     -httpd /usr/share/kasmvnc/www \
-    -select-de xfce \
+    -Log *:stderr:10 \
     -fg
+

--- a/plugins/connectors/vnc/Dockerfile
+++ b/plugins/connectors/vnc/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     novnc \
     websockify \
     python3-numpy \
+    && apt-get autoremove -y && \
+    rm -rf /usr/share/doc/* /usr/share/info/* /usr/share/lintian/* /usr/share/man/* \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Fix noVNC index (redirect to vnc.html)

--- a/plugins/connectors/vnc/startup.sh
+++ b/plugins/connectors/vnc/startup.sh
@@ -10,6 +10,16 @@ VNC_PW=${VNC_PW}
 export USER=${USER}
 export HOME=${HOME}
 
+# Cinnamon (a GNOME fork) requires a per-user runtime directory for its
+# session bus and dconf; on a normal login systemd creates /run/user/$UID
+# and exports XDG_RUNTIME_DIR, but in a container there is no systemd login.
+# Without it the session dies right after authentication -> black desktop.
+RUNTIME_DIR="/run/user/$(id -u)"
+if [ ! -d "$RUNTIME_DIR" ]; then
+    sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" "$RUNTIME_DIR"
+fi
+export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+
 # Cleanup locks
 # Cleanup locks
 rm -f /tmp/.X1-lock /tmp/.X11-unix/X1
@@ -31,12 +41,34 @@ mkdir -p $HOME/.vnc
 echo "$VNC_PW" | vncpasswd -f > $HOME/.vnc/passwd
 chmod 600 $HOME/.vnc/passwd
 
-# Setup xstartup for XFCE4
+# Setup xstartup for Desktop Session. The desktop-session launcher is owned
+# by the desktop plugin; wrapping it in dbus-launch guarantees a session bus
+# for the DE (Cinnamon requires one) and exports DBUS_SESSION_BUS_ADDRESS to
+# every app it spawns.
+#
+# Before the session starts we (1) run vncconfig -nowin, which bridges the
+# X11 CLIPBOARD selection to the VNC/RFB clipboard so the client can copy
+# and paste in both directions (required by TigerVNC; KasmVNC ships the same
+# tool), and (2) merge the desktop's X resources (xterm font + clipboard
+# selection, shipped by the openbox plugin) into the server. Both are guarded
+# so connectors work on desktops that ship neither.
 cat > $HOME/.vnc/xstartup <<EOF
 #!/bin/sh
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
-exec startxfce4
+if command -v vncconfig >/dev/null 2>&1; then
+    vncconfig -nowin &
+fi
+if command -v xrdb >/dev/null 2>&1 && [ -d /etc/X11/Xresources ]; then
+    for f in /etc/X11/Xresources/*; do
+        [ -f "\$f" ] && xrdb -merge "\$f"
+    done
+fi
+if [ -x /usr/local/bin/desktop-session ]; then
+    exec dbus-launch --exit-with-session /usr/local/bin/desktop-session
+else
+    exec dbus-launch --exit-with-session startxfce4
+fi
 EOF
 chmod +x $HOME/.vnc/xstartup
 


### PR DESCRIPTION
…yers

Stable localhost CA + server cert baked at build time (SAN DNS:localhost, IP:127.0.0.1) so a single CA import survives re-creations. Both VNC-family xstartups run vncconfig -nowin (CLIPBOARD bridging) and merge /etc/X11/Xresources via xrdb; vnc layer gets autoremove/doc hygiene.